### PR TITLE
Add project reference to TSQLSmellsSCA

### DIFF
--- a/RunSCAAnalysis/RunSCAAnalysis.csproj
+++ b/RunSCAAnalysis/RunSCAAnalysis.csproj
@@ -53,6 +53,12 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TSQLSmellSCA\TSQLSmellSCA.csproj">
+      <Project>{0e07f4cd-6cdb-4b3a-b8d5-f88b3b26e58c}</Project>
+      <Name>TSQLSmellSCA</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Adding a project reference means TSQLSmellsSCA.DLL is copied to RunSCAAnalysis bin folder. Which means the smells are found by Microsoft.SqlServer.Dac.DLL even though they are not in the VS Extensions folder. This means the command line utility can be used on servers that don't have VS installed.
